### PR TITLE
Use tweepy to simplify sopel-twitter and add features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 sopel>=6.5,<7
-oauth2
-tweepy>=3.5.0,<4
+tweepy>=3.6.0,<4

--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -43,7 +43,13 @@ def get_tweet(bot, trigger, match):
     api = create_api(bot.config.twitter)
 
     tweet_id = match.group(2)
-    tweet = api.get_status(tweet_id, tweet_mode='extended')
+    try:
+        tweet = api.get_status(tweet_id, tweet_mode='extended')
+    except tweepy.TweepError as e:
+        logger.exception('{} raised from looking up tweet_id={}'
+                         .format(e, tweet_id))
+        return bot.say('[Twitter] Error: link to a deleted, private or invalid'
+                       ' tweet ID.')
     tweet.full_text = tweet.full_text.replace('\n', ' ')
 
     message = ('[Twitter] {tweet.full_text} | {tweet.user.name} '
@@ -83,7 +89,11 @@ def get_tweet(bot, trigger, match):
 def get_profile(bot, trigger, match):
     api = create_api(bot.config.twitter)
     sn = match.group(1)
-    user = api.get_user(screen_name=sn)
+    try:
+        user = api.get_user(screen_name=sn)
+    except tweepy.TweepError:
+        logger.exception('{} raised from looking up @{}'.format(e, user))
+        return bot.say('[Twitter] Error: Invalid twitter handle.')
 
     desc = user.description
     for url in user.entities['description']['urls']:


### PR DESCRIPTION
Overview of changes:
- Dropped dependencies on oauth and json
- Added dependency on [tweepy](https://github.com/tweepy/tweepy)
- Config will request access tokens for user auth
- Better handling of twitter URLs
- If twitter URL is for a profile, a summary of the twitter profile is provided
- Tweet text will go beyond the legacy 140 char limit

----

## Maintainers' addendum (mostly @dgw)

Candidates for new PRs:

- [x] Handle profile links (`twitter.com/<name>`), too (done: #7)
- [x] Go beyond 140 characters (done: #4)
- [x] Improve tweet link handling to cover more possibilities seen in the wild
  - Obviously this one will crib a lot from @freeboson's work, but fortunately we have the ability to credit co-authors in commit messages.
- [x] Better error handling (done: #6)

As for why not merge this PR as-is: I don't really want to switch this plugin over to tweepy. That, and @freeboson has been pretty quiet about possibly rebasing/cleaning up the history.