### PR TITLE
Support >140 character tweets without truncation

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -48,6 +48,7 @@ def get_url(bot, trigger, match):
         text = content['full_text']
     except KeyError:
         text = content['text']
+    text.replace("\n", " \u23CE ")  # Unicode symbol to indicate line-break
     message = ('[Twitter] {text} | {content[user][name]} '
                '(@{content[user][screen_name]}) | {content[retweet_count]} RTs '
                '| {content[favorite_count]} ♥s').format(content=content, text=text)

--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -38,15 +38,19 @@ def get_url(bot, trigger, match):
     client = oauth.Client(consumer)
     id_ = match.group(2)
     response, content = client.request(
-        'https://api.twitter.com/1.1/statuses/show/{}.json'.format(id_))
+        'https://api.twitter.com/1.1/statuses/show/{}.json?tweet_mode=extended'.format(id_))
     if response['status'] != '200':
         logger.error('%s error reaching the twitter API for %s',
                      response['status'], match.group(0))
 
     content = json.loads(content.decode('utf-8'))
-    message = ('[Twitter] {content[text]} | {content[user][name]} '
+    try:
+        text = content['full_text']
+    except KeyError:
+        text = content['text']
+    message = ('[Twitter] {text} | {content[user][name]} '
                '(@{content[user][screen_name]}) | {content[retweet_count]} RTs '
-               '| {content[favorite_count]} ♥s').format(content=content)
+               '| {content[favorite_count]} ♥s').format(content=content, text=text)
     all_urls = content['entities']['urls']
     if content['is_quote_status']:
         message += ('| Quoting {content[quoted_status][user][name]} '


### PR DESCRIPTION
Twitter has moved away from the classic 140-character limit in recent years. Considerably longer tweets are possible, especially if one counts attached media, links, & `@` mentions that might be excluded from the calculated text length. If we ask for "extended" tweet mode, we can display the full text!

I adapted the try/except thing from my personal copy of `twit.py`, forked from sopel-extras. Older tweets might still return JSON without the `full_text` key, if memory serves (it's been a while). At any rate, the cost of checking for an exception is minimal, far outweighed by the benefits of catching one if some old tweet link returns an outdated data layout.