### PR TITLE
Handle profile links

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -34,6 +34,14 @@ def setup(bot):
     bot.config.define_section('twitter', TwitterSection)
 
 
+def get_client(bot):
+    """Utility to get an OAuth client. Reduces boilerplate."""
+    return oauth.Client(
+        oauth.Consumer(
+            key=bot.config.twitter.consumer_key,
+            secret=bot.config.twitter.consumer_secret))
+
+
 def get_extended_media(tweet):
     """
     Twitter annoyingly only returns extended_entities if certain entities exist.
@@ -88,11 +96,7 @@ def format_tweet(tweet):
 
 @module.url('https?://twitter.com/([^/]*)(?:/status/(\\d+)).*')
 def get_url(bot, trigger, match):
-    consumer_key = bot.config.twitter.consumer_key
-    consumer_secret = bot.config.twitter.consumer_secret
-
-    consumer = oauth.Consumer(key=consumer_key, secret=consumer_secret)
-    client = oauth.Client(consumer)
+    client = get_client(bot)
     id_ = match.group(2)
     response, content = client.request(
         'https://api.twitter.com/1.1/statuses/show/{}.json?tweet_mode=extended'.format(id_))

--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -182,18 +182,26 @@ def output_user(bot, trigger, sn):
     joined = datetime.strptime(user['created_at'], '%a %b %d %H:%M:%S %z %Y')
     tz = time.get_timezone(
         bot.db, bot.config, None, trigger.nick, trigger.sender)
-    joined_localized = time.format_time(
+    joined = time.format_time(
         bot.db, bot.config, tz, trigger.nick, trigger.sender, joined)
+
+    if user.get('description', None):
+        bio = user['description']
+        for link in user['entities']['description']['urls']:  # bloody t.co everywhere
+            bio = bio.replace(link['url'], link['expanded_url'])
+    else:
+        bio = ''
 
     message = ('[Twitter] {user[name]} (@{user[screen_name]}){verified}{protected}{location}{url}'
                ' | {user[friends_count]:,} friends, {user[followers_count]:,} followers'
                ' | {user[statuses_count]:,} tweets, {user[favourites_count]:,} ♥s'
-               ' | Joined: {abstime}').format(
+               ' | Joined: {joined}{bio}').format(
                user=user,
                verified=(' ✔️' if user['verified'] else ''),
                protected=(' 🔒' if user['protected'] else ''),
                location=(' | ' + user['location'] if user.get('location', None) else ''),
                url=(' | ' + url if url else ''),
-               abstime=joined_localized)
+               joined=joined,
+               bio=(' | ' + bio if bio else ''))
 
     bot.say(message)

--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -7,10 +7,9 @@ import re
 
 import oauth2 as oauth
 
-from sopel import module
+from sopel import module, tools
 from sopel.config.types import StaticSection, ValidatedAttribute, NO_DEFAULT
 from sopel.logger import get_logger
-from sopel.tools import time
 
 logger = get_logger(__name__)
 
@@ -180,9 +179,9 @@ def output_user(bot, trigger, sn):
         url = ''
 
     joined = datetime.strptime(user['created_at'], '%a %b %d %H:%M:%S %z %Y')
-    tz = time.get_timezone(
+    tz = tools.time.get_timezone(
         bot.db, bot.config, None, trigger.nick, trigger.sender)
-    joined = time.format_time(
+    joined = tools.time.format_time(
         bot.db, bot.config, tz, trigger.nick, trigger.sender, joined)
 
     if user.get('description', None):
@@ -204,4 +203,9 @@ def output_user(bot, trigger, sn):
                joined=joined,
                bio=(' | ' + bio if bio else ''))
 
+    # It's unlikely to happen, but theoretically we *might* need to truncate the message if enough
+    # of the field values are ridiculously long. Best to be safe.
+    message, excess = tools.get_sendable_message(message)
+    if excess:
+        message += ' […]'
     bot.say(message)


### PR DESCRIPTION
This should be stable, even if the details provided for a profile in the code at time of PR opening are currently minimal. Including more information is planned; see below.

```
<dgw>        https://twitter.com/hidgw
<SopelTest>  [Twitter] dgw (@hidgw) | 724 friends, 1,355 followers | 30,665 tweets, 12,100 ♥s
```

Checklist of stuff to output:

- [x] Name
- [x] Handle (duh)
- [x] Following count
- [x] Follower count
- [x] Tweet count
- [x] Favorites/Likes count
- [x] Website/link on profile
  - Twitter uses `t.co` for these, so they'll have to be expanded… 🙁
  - ^ Fortunately, the user object also includes the required entity data
- [x] Profile bio
  - These can be up to 160(?) characters; should probably be output last to allow for truncation
- [x] Location (string version)?
- [x] Account creation time ~~/ age~~?