### PR TITLE
Overhaul for Sopel 7

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,28 @@
+Changes between 0.1.2 and 0.2.0
+===============================
+
+Changed:
+* Now requires Sopel 7.x
+* Newlines in tweet text will be replaced with a carriage return symbol, to
+  indicate author intention
+
+Added:
+* Handling of 280-character tweets
+* More graceful handling of API errors
+
+Meta:
+* Package metadata updated (new maintainer, HTTPS links)
+
+
+Changes between 0.1.1 and 0.1.2
+===============================
+
+Added:
+* Tweet link handling
+
+
+Changes between 0.1.0 and 0.1.1
+===============================
+
+Fixed:
+* Unicode on Python 3

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
-# Sopel Twitter
+# sopel-twitter
 
-A Twitter module for Sopel. API key comes from https://apps.twitter.com . Click "Create a new app", and enter the required fields. Don't bother with a callback url.
+A Twitter plugin for Sopel.
+
+You'll need an API key from https://apps.twitter.com/. Click "Create a new
+app", and enter the required fields. Don't bother with a callback URL.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-sopel>=6.5,<7
-oauth2
+sopel>=7,<8
+oauth2<2.0

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,12 @@ with open('dev-requirements.txt') as dev_requirements_file:
 
 setup(
     name='sopel_modules.twitter',
-    version='0.1.2',
+    version='0.2.0',
     description='A Twitter module for Sopel',
     long_description=readme + '\n\n' + history,
-    author='Elsie Powell',
-    author_email='elsie@elsiepowell.com',
-    url='http://github.com/sopel-irc/sopel-twitter',
+    author='dgw',
+    author_email='dgw@technobabbl.es',
+    url='https://github.com/sopel-irc/sopel-twitter',
     packages=find_packages('.'),
     namespace_packages=['sopel_modules'],
     include_package_data=True,

--- a/sopel_modules/twitter/__init__.py
+++ b/sopel_modules/twitter/__init__.py
@@ -1,13 +1,13 @@
 # coding=utf8
-"""Sopel Twitter
+"""sopel-twitter
 
-A Twitter module for Sopel
+A Twitter plugin for Sopel
 """
 from __future__ import unicode_literals, absolute_import, division, print_function
 
 from .twitter import *
 
-__author__ = 'Elsie Powell'
-__email__ = 'elsie@elsiepowell.com'
-__version__ = '0.1.0'
+__author__ = 'dgw'
+__email__ = 'dgw@technobabbl.es'
+__version__ = '0.2.0'
 

--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -29,7 +29,7 @@ def setup(bot):
     bot.config.define_section('twitter', TwitterSection)
 
 
-@module.url('https?://twitter.com/([^/]*)(?:/status/(\d+)).*')
+@module.url('https?://twitter.com/([^/]*)(?:/status/(\\d+)).*')
 def get_url(bot, trigger, match):
     consumer_key = bot.config.twitter.consumer_key
     consumer_secret = bot.config.twitter.consumer_secret


### PR DESCRIPTION
* Updated readme
* Backfilled NEWS file with prior versions' changes
* Fixed deprecated Python syntax
* Tightened up requirements

This is one of the few "official" plugins maintained by the Sopel org on GitHub that already used the URL decorator despite its issues in older Sopel releases (i.e. not working if the `url` module was disabled).