### PR TITLE
twitter: Handle tweet URLs of the `/i/web/status` form

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -95,15 +95,20 @@ def format_tweet(tweet):
     return u['name'] + ' (@' + u['screen_name'] + '): ' + text
 
 
-@module.url(r'https?://twitter.com/([^/]*)(?:/status/(\d+))?.*')
+@module.url(r'https?://twitter\.com/(?P<user>[^/]*)(?:/status/(?P<status>\d+))?.*')
+@module.url(r'https?://twitter\.com/i/web/status/(?P<status>\d+).*')
 def get_url(bot, trigger, match):
-    sn = match.group(1)
-    id_ = match.group(2)
-
-    if id_:
-        output_status(bot, id_)
+    try:
+        status = match.group('status')
+    except IndexError:
+        try:
+            user = match.group('user')
+        except IndexError:
+            return  # don't know how to handle this link; silently fail
+        else:
+            output_user(bot, trigger, user)
     else:
-        output_user(bot, trigger, sn)
+        output_status(bot, status)
 
 
 def output_status(bot, id_):


### PR DESCRIPTION
I created this feature branch on my last day in the office before we stopped going in for COVID-19.

Super happy that my past self pushed it up to GitHub; my office desktop doesn't have remote access, and no one has _ever_ said, "Designing that regex will be even _more_ fun the second time!"

So, though I forgot about it for a couple weeks, the testing can continue now.