### PR TITLE
Avoid matching e.g. `/i/events/1234567890` as a link to i's user profile

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -141,7 +141,7 @@ def format_time(bot, trigger, stamp):
         bot.db, bot.config, tz, trigger.nick, trigger.sender, parsed)
 
 
-@module.url(r'https?://twitter\.com/(?P<user>[^/]*)(?:/status/(?P<status>\d+))?.*')
+@module.url(r'https?://twitter\.com/(?P<user>[^/]+)(?:$|/status/(?P<status>\d+)).*')
 @module.url(r'https?://twitter\.com/i/web/status/(?P<status>\d+).*')
 def get_url(bot, trigger, match):
     try:


### PR DESCRIPTION
Tightening the regex to match either ONLY a user, or a user AND status ID, should reduce instances of the bot saying "Twitter returned an error" at random links that happen to contain `twitter.com` but aren't one of the kinds we handle.

Could have just fixed this in the actual code, and ignored matches with username 'i' and no status ID, but Twitter *could* allow someone to register that name in the future.