### PR TITLE
Add Twitter's mobile subdomains for URL handling

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -141,7 +141,7 @@ def format_time(bot, trigger, stamp):
         bot.db, bot.config, tz, trigger.nick, trigger.sender, parsed)
 
 
-@module.url(r'https?://twitter\.com/(?P<user>[^/]+)(?:$|/status/(?P<status>\d+)).*')
+@module.url(r'https?://(?:m(?:obile)\.)?twitter\.com/(?P<user>[^/]+)(?:$|/status/(?P<status>\d+)).*')
 @module.url(r'https?://twitter\.com/i/web/status/(?P<status>\d+).*')
 def get_url(bot, trigger, match):
     things = match.groupdict()

--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -141,8 +141,8 @@ def format_time(bot, trigger, stamp):
         bot.db, bot.config, tz, trigger.nick, trigger.sender, parsed)
 
 
-@module.url(r'https?://(?:m(?:obile)\.)?twitter\.com/(?P<user>[^/]+)(?:$|/status/(?P<status>\d+)).*')
-@module.url(r'https?://twitter\.com/i/web/status/(?P<status>\d+).*')
+@module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/(?P<user>[^/]+)(?:$|/status/(?P<status>\d+)).*')
+@module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/i/web/status/(?P<status>\d+).*')
 def get_url(bot, trigger, match):
     things = match.groupdict()
     user = things.get('user', None)


### PR DESCRIPTION
`m.` redirects to `mobile.` and might never actually be in a link, but it's no big deal to include it too.

Note: Need to put this through some more rigorous regex tests before merging/releasing.