### PR TITLE
users: handle trailing get vars and slashes

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -144,7 +144,7 @@ def format_time(bot, trigger, stamp):
         bot.db, bot.config, tz, trigger.nick, trigger.sender, parsed)
 
 
-@module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/(?P<user>[^/]+)(?:$|/status/(?P<status>\d+)).*')
+@module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/(?P<user>\w+)(?:/status/(?P<status>\d+))?')
 @module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/i/web/status/(?P<status>\d+).*')
 def get_url(bot, trigger, match):
     things = match.groupdict()


### PR DESCRIPTION
The plugin currently does not correctly handle some twitter-generated links like `https://twitter.com/NASA?lang=en` ("User not found") or some user-generated links like `https://twitter.com/NASA/` (note trailing slash: doesn't match at all).

Current regex:
![Screenshot showing regex failing to correctly match those cases](https://user-images.githubusercontent.com/1053010/137526946-962319cf-55d8-47e3-ba50-b3de305ca1ed.png)

New regex:
![Screenshot showing regex matching user links and tweet links regardless of trailing slash or get parameters](https://user-images.githubusercontent.com/1053010/137527172-a4ac43dd-8286-4594-baf4-d0ba567fa483.png)
