### PR TITLE
Fix `/i/web/status/n` links

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -13,6 +13,8 @@ from sopel.logger import get_logger
 
 logger = get_logger(__name__)
 
+DOMAIN_REGEX = r"https?://(?:m(?:obile)?\.)?twitter\.com/"
+
 
 class TwitterSection(StaticSection):
     consumer_key = ValidatedAttribute('consumer_key', default=NO_DEFAULT)
@@ -144,21 +146,14 @@ def format_time(bot, trigger, stamp):
         bot.db, bot.config, tz, trigger.nick, trigger.sender, parsed)
 
 
-@module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/(?P<user>\w+)(?:/status/(?P<status>\d+))?')
-@module.url(r'https?://(?:m(?:obile)?\.)?twitter\.com/i/web/status/(?P<status>\d+).*')
-def get_url(bot, trigger, match):
-    things = match.groupdict()
-    user = things.get('user', None)
-    status = things.get('status', None)
+@module.url(DOMAIN_REGEX + r"(?:\w+|i/web)/status/(?P<status>\d+)")
+def url_status(bot, trigger):
+    output_status(bot, trigger, trigger.group("status"))
 
-    if status:
-        output_status(bot, trigger, status)
-    elif user:
-        output_user(bot, trigger, user)
-    else:
-        # don't know how to handle this link; silently fail
-        # explicit is better than implicit
-        return
+
+@module.url(DOMAIN_REGEX + r"(?P<user>\w+)/?(?:\?.*)?$")
+def url_user(bot, trigger):
+    output_user(bot, trigger, trigger.group("user"))
 
 
 @module.commands('twitinfo')


### PR DESCRIPTION
It's probably better to explicitly match the full URL for non-status stuff?

Also added fxtwitter.com support while I'm mucking with regexes :shushing_face:

![image](https://user-images.githubusercontent.com/1053010/167321322-6c58f3b8-5bd0-42cd-85af-393d97d5469b.png)

Addl test cases:
```
https://twitter.com/i/web/status/1514372885758025728
https://twitter.com/i/web/status/1514372885758025728/
https://twitter.com/i/web/status/1514372885758025728?s=20
https://twitter.com/i/web/status/1514372885758025728/?s=20
https://twitter.com/i/?s=20
https://twitter.com/i/status/1514372885758025728/?s=20
https://fxtwitter.com/NASA/status/1514372885758025728/?s=20
```

Fixes #32