### PR TITLE
collapse whitespace with 1+ newline to one newline

### DIFF
--- a/sopel_modules/twitter/twitter.py
+++ b/sopel_modules/twitter/twitter.py
@@ -22,6 +22,7 @@ logger = get_logger(__name__)
 DOMAIN_REGEX = r"https?://(?:m(?:obile)?\.)?twitter\.com/"
 STATUS_REGEX = r"(?:\w+|i/web)/status/(?P<status>\d+)"
 USER_REGEX = r"(?P<user>\w+)/?(?:\?.*)?$"
+NEWLINE_RUN_REGEX = re.compile(r"\s*\n[\n\s]*")
 
 
 class TwitterSection(StaticSection):
@@ -107,6 +108,7 @@ def format_tweet(tweet):
         text = tweet['full_text']
     except KeyError:
         text = tweet['text']
+    text = NEWLINE_RUN_REGEX.sub("\n", text)
     text = text.replace("\n", " \u23CE ")  # Unicode symbol to indicate line-break
     urls = tweet['entities']['urls']
     media = get_extended_media(tweet)


### PR DESCRIPTION
Example: https://twitter.com/NASAWebb/status/1545413807996129280
Current: `< Sopel> [Twitter] NASA Webb Telescope (@NASAWebb): 🎯 Target(s) acquired!   ⏎  ⏎ The targets of Webb’s first images have been announced: https://go.nasa.gov/3ysrC73 ⏎  ⏎ ✨ SMACS 0723  ⏎  ⏎ ✨ WASP-96b  ⏎  ⏎ ✨ Southern Ring Nebula  ⏎  ⏎ ✨ Stephan’s Quintet  ⏎  ⏎ ✨ Carina Nebula  ⏎  ⏎ Tune in July 12 as we reveal Webb’s first images & #UnfoldTheUniverse. https://pbs.twimg.com/media/FXJpp-XX0AAhLuj.jpg | 2621 RTs | 10159 ?`
Proposed: `< Sopel> [Twitter] NASA Webb Telescope (@NASAWebb): 🎯 Target(s) acquired! ⏎ The targets of Webb’s first images have been announced: https://go.nasa.gov/3ysrC73 ⏎ ✨ SMACS 0723 ⏎ ✨ WASP-96b ⏎ ✨ Southern Ring Nebula ⏎ ✨ Stephan’s Quintet ⏎ ✨ Carina Nebula ⏎ Tune in July 12 as we reveal Webb’s first images & #UnfoldTheUniverse. https://pbs.twimg.com/media/FXJpp-XX0AAhLuj.jpg | 2621 RTs | 10159 ♥s | Posted: 2022-07-08 - 14:25:38UTC`

This saves enough bytes (5 for each newline removed: `b' \xe2\x8f\x8e '`, plus spaces) that the likes and entire post date can now fit too.