### PR TITLE
Migrate to Tweety for data fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,20 +2,6 @@
 
 A Twitter plugin for [Sopel](https://sopel.chat/).
 
-## Getting your API credentials
-
-Twitter's [developer application
-process](https://developer.twitter.com/en/docs/twitter-api/getting-started/getting-access-to-the-twitter-api)
-has become rather tedious and annoying, involving a game of 20 questions with
-manual verification and sometimes long wait times. Unfortunately you'll need
-to go through it in order to use this plugin, since the API is needed to
-retrieve account data and rich link previews.
-
-Once you have a Twitter developer account, you can [create an
-app](https://developer.twitter.com/en/portal/apps/new) for your instance of
-sopel-twitter. You'll need the API Key (`consumer_key`) and Secret
-(`consumer_secret`) for your bot configuration.
-
 ## Installation
 
 Releases are hosted on PyPI, so after installing Sopel, all you need is `pip`:

--- a/README.md
+++ b/README.md
@@ -23,17 +23,16 @@ Otherwise, you can edit your bot's configuration file:
 
 ```ini
 [twitter]
-consumer_key = YOUR_API_KEY_HERE
-consumer_secret = YOUR_API_SECRET_HERE
+show_quoted_tweets = True
 # Optional: For quote-tweets, send a second message showing the quoted tweet?
 # Default: True
-show_quoted_tweets = True
-# Optional: What other domains should we treat like twitter domains?
-# Default: vxtwitter.com, nitter.net
+
 alternate_domains =
     fxtwitter.com
     vxtwitter.com
     nitter.net
+# Optional: What other domains should we treat like twitter domains?
+# Default: vxtwitter.com, nitter.net
 ```
 
 ## Usage

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = false
 include_package_data = true
 install_requires =
     sopel>=7.0,<8
-    oauth2<2.0
+    tweety-ns>=0.6,<0.7
 
 [options.entry_points]
 sopel.plugins =

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,7 @@ packages = find:
 zip_safe = false
 include_package_data = true
 install_requires =
-    sopel>=7.0,<8
+    sopel>=7.1,<8
     tweety-ns>=0.6.1,<0.7
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = false
 include_package_data = true
 install_requires =
     sopel>=7.0,<8
-    tweety-ns>=0.6,<0.7
+    tweety-ns>=0.6.1,<0.7
 
 [options.entry_points]
 sopel.plugins =

--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -225,9 +225,4 @@ def output_user(bot, trigger, sn):
                joined=format_time(bot, trigger, user['created_at']),
                bio=(' | ' + bio if bio else ''))
 
-    # It's unlikely to happen, but theoretically we *might* need to truncate the message if enough
-    # of the field values are ridiculously long. Best to be safe.
-    message, excess = tools.get_sendable_message(message)
-    if excess:
-        message += ' […]'
-    bot.say(message)
+    bot.say(message, truncation=' […]')

--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -60,10 +60,9 @@ def format_tweet(tweet):
     media = tweet.media
 
     # Remove link to quoted status itself, if it's present
-    # TODO: not yet functional in Tweety rewrite
     if tweet.is_quoted:
         for url in urls:
-            if url['expanded_url'].rsplit('/', 1)[1] == tweet['quoted_status_id_str']:
+            if url['expanded_url'].rsplit('/', 1)[1] == tweet.quoted_tweet.id:
                 # this regex matches zero-or-more whitespace behind the link, but
                 # whitespace after the link only matches if it's trailing (that is,
                 # not followed by more non-whitespace characters).
@@ -161,22 +160,22 @@ def output_status(bot, trigger, id_):
                             hearts=tweet.likes,
                             posted=format_time(bot, trigger, tweet.created_on)))
 
-    # TEMPORARY early return until quoted tweet logic is worked out
-    return
-
     if (
-        tweet['is_quote_status']
-        and 'quoted_status' in tweet
-        and bot.config.twitter.show_quoted_tweets
+        bot.config.twitter.show_quoted_tweets
+        and tweet.is_quoted
+        and tweet.quoted_tweet is not None
     ):
-        tweet = tweet['quoted_status']
+        tweet = tweet.quoted_tweet
         bot.say(template.format(tweet='Quoting: ' + format_tweet(tweet),
-                                RTs=tweet['retweet_count'],
-                                hearts=tweet['favorite_count'],
-                                posted=format_time(bot, trigger, tweet['created_at'])))
+                                RTs=tweet.retweet_counts,
+                                hearts=tweet.likes,
+                                posted=format_time(bot, trigger, tweet.created_on)))
 
 
 def output_user(bot, trigger, sn):
+    # early return; not implemented yet w/Tweety
+    return
+
     client = get_client(bot)
     response, content = client.request(
         'https://api.twitter.com/1.1/users/show.json?screen_name={}'.format(sn))


### PR DESCRIPTION
Who needs to migrate to Twitter's annoying _and_ (now) expensive v2 API (#23) when you can just use `tweety-ns`?

I have tested a sampling of Tweet and profile links chosen from my "home timeline" (which is as likely as not now to show tweets from people I've never followed, or even interacted with at all), containing pictures, GIFs, videos, and quoted tweets. So far as I can tell, this rewrite is one-for-one feature-complete vs. the old code using Twitter API v1 directly. It's also being tested in #sopel at Libera (not that we frequently post Twitter links there).

_The history here is very messy to start, because the `tweety-ns` package had a few show-stopping bugs as of early February that made me halt the rewrite for several weeks—but I definitely wanted a record of the original rewrite timeline. With the PR ready, it might be the first squash-merge ever for this repo if I can't come up with a nice way to rewrite the commit log._