### PR TITLE
Construct new Tweety instance for each tweet

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -44,7 +44,6 @@ def configure(config):
 
 def setup(bot):
     bot.config.define_section('twitter', TwitterSection)
-    bot.memory['tweety_app'] = Twitter()
 
 
 def get_preferred_media_item_link(item):
@@ -180,7 +179,7 @@ def user_command(bot, trigger):
 
 def output_status(bot, trigger, id_):
     try:
-        tweet = bot.memory['tweety_app'].tweet_detail(id_)
+        tweet = Twitter().tweet_detail(id_)
     except tweety_errors.InvalidTweetIdentifier:
         bot.say("Couldn't fetch that tweet. Most likely, it's either private or deleted.")
         return


### PR DESCRIPTION
Seems that keeping a Tweety instance around for too long doesn't work. It'll eventually start failing to fetch tweets. Probably some secret involved that's time-derived.

Not knowing the "safe" time interval to keep using a single Tweety instance, I have chosen the nuclear option: No optimization at all. (In the future I might implement some smart-retry logic to cache a Tweety instance but replace it with a fresh one before erroring, but let's see if the performance hit is big enough to warrant that work.)