### PR TITLE
Refresh Tweety instance less often

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -44,6 +44,14 @@ def configure(config):
 
 def setup(bot):
     bot.config.define_section('twitter', TwitterSection)
+    bot.memory['tweety_app'] = Twitter()
+
+
+def shutdown(bot):
+    try:
+        del bot.memory['tweety_app']
+    except KeyError:
+        pass
 
 
 def get_preferred_media_item_link(item):
@@ -178,18 +186,27 @@ def user_command(bot, trigger):
 
 
 def output_status(bot, trigger, id_):
-    try:
-        tweet = Twitter().tweet_detail(id_)
-    except tweety_errors.InvalidTweetIdentifier:
-        bot.say("Couldn't fetch that tweet. Most likely, it's either private or deleted.")
-        return
-    except (
-        tweety_errors.GuestTokenNotFound,
-        tweety_errors.ProxyParseError,
-        tweety_errors.UnknownError,
-    ):
-        bot.say("Can't access Twitter data. Please try again later.")
-        return
+    for retried in range(2):
+        try:
+            tweet = bot.memory['tweety_app'].tweet_detail(id_)
+        except tweety_errors.InvalidTweetIdentifier:
+            if not retried:
+                # try a fresh instance
+                bot.memory['tweety_app'] = Twitter()
+                continue
+            else:
+                # still fails? probably unfetchable
+                bot.say("Couldn't fetch that tweet. Most likely, it's either private or deleted.")
+                return
+        except (
+            tweety_errors.GuestTokenNotFound,
+            tweety_errors.ProxyParseError,
+            tweety_errors.UnknownError,
+        ):
+            bot.say("Can't access Twitter data. Please try again later.")
+            return
+        else:
+            break
 
     template = "[Twitter] {tweet} | {RTs} RTs | {hearts} ♥s | Posted: {posted}"
 


### PR DESCRIPTION
Built on #43, which is the "quick fix" that can be released immediately. Will save this for a future patch release, after much better testing than I can do in one day.

Also reorganizes some error handling. Examining the Tweety code, I found that some cases won't ever happen outside of constructing a new object instance, so those have been encapsulated in a helper.