### PR TITLE
Rework to function with cookies & update to tweety-ns 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,27 @@ If you want to use the development version, simply clone the repository and use
 
 ## Configuring
 
-The easiest way to configure `sopel-twitter` is using Sopel's configuration
-wizard – simply run `sopel-plugins configure twitter` and enter the
-credentials for the Twitter application you created.
+**Twitter cookies are required to use this plugin** as of 1 July 2023. You may
+want to minimize the risk of adverse action by using a throwaway login instead
+of your real profile; however, note that doing so will affect the rate limit
+available to this plugin.
+
+The easiest way to configure `sopel-twitter` is via Sopel's configuration
+wizard – simply run `sopel-plugins configure twitter` and enter the cookie
+values for which it prompts you.
 
 Otherwise, you can edit your bot's configuration file:
 
 ```ini
 [twitter]
+cookies =
+    auth_token=df4c7364f4fac2b3843904ecc566b0e1accdf98b;
+    ct0=23f96509cba936b732cd39e171dce0fa5da9ecd1d7f3551258fe3e1a21da79a797e80496e8190613ba8a8ebc07ef6d8004b17518e84f9b6f8100738c5243a3da3139c87a5a55e46d70ed99cf0f068a23
+# Required: Cookies from Twitter
+# Newlines are not required, but the semicolon (;) very much is!
+# You will have to pull this from your own logged-in account; rate limits will
+# vary depending on the account's verification/Blue status.
+
 show_quoted_tweets = True
 # Optional: For quote-tweets, send a second message showing the quoted tweet?
 # Default: True
@@ -32,7 +45,7 @@ alternate_domains =
     vxtwitter.com
     nitter.net
 # Optional: What other domains should we treat like twitter domains?
-# Default: vxtwitter.com, nitter.net
+# Default: fxtwitter.com, vxtwitter.com, nitter.net
 ```
 
 ## Usage

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = false
 include_package_data = true
 install_requires =
     sopel>=7.1,<9
-    tweety-ns~=0.7.1
+    tweety-ns~=0.8.0
 
 [options.entry_points]
 sopel.plugins =


### PR DESCRIPTION
Lots of stuff changed this week, breaking the old library version AND adding required authentication to fetch any data on the new endpoints. Cookies are now required.

Recommending that people do not use credentials for their main Twitter account out of an abundance of caution; one never knows the possible consequences of associating an account you actually care about with a tool like this.