### PR TITLE
Specify path in which to save tweety session files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,16 +46,16 @@ alternate_domains =
 
 ### Important note
 
-The library this plugin uses for Twitter data access stores its login session
-data in **the current working directory**. For Sopel, that is the directory
-from which the `sopel` command is run.
+The library this plugin uses for Twitter data access previously stored its
+login session data in **the current working directory**. For Sopel, that was
+the directory from which the `sopel` command was run.
 
-A future library release promises to add support for specifying where to store
-session data, at which point this plugin will be updated to use the `homedir`
-of Sopel's configuration (`~/.sopel` by default). You will be able to locate
-the old session files by running e.g. `find / -type f -name
-'sopel-twitter*.json' 2>/dev/null`. (Running `find` on `/` tends to output
-numerous "Permission denied" errors, so suppressing stderr is recommended.)
+As of sopel-twitter 1.3.1, a newer library version became available with
+support for storing session data in Sopel's `homedir` instead. You can clean
+up the old session files left behind by sopel-twitter 1.3.0 by running e.g.
+`find / -type f -name 'sopel-twitter*.json' 2>/dev/null`. (Running `find` on
+`/` tends to output numerous "Permission denied" errors, so suppressing stderr
+is recommended.)
 
 ## Usage
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = false
 include_package_data = true
 install_requires =
     sopel>=7.1,<9
-    tweety-ns~=0.9.0
+    tweety-ns~=0.9.5
 
 [options.entry_points]
 sopel.plugins =

--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -61,7 +61,7 @@ def _get_tweety_session_name(bot):
     """Return a session name for this plugin + bot config."""
     return os.path.join(
         _get_tweety_session_path(bot),
-        "sopel-twitter.{}".format(bot.settings.basename)
+        "{}.sopel-twitter".format(bot.settings.basename)
     )
 
 

--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -7,6 +7,7 @@ from __future__ import unicode_literals, absolute_import, division, print_functi
 
 from datetime import datetime
 import json
+import os.path
 import re
 
 from tweety import Twitter, exceptions_ as tweety_errors
@@ -58,7 +59,15 @@ def setup(bot):
 
 def _get_tweety_session_name(bot):
     """Return a session name for this plugin + bot config."""
-    return "sopel-twitter.{}".format(bot.settings.basename)
+    return os.path.join(
+        _get_tweety_session_path(bot),
+        "sopel-twitter.{}".format(bot.settings.basename)
+    )
+
+
+def _get_tweety_session_path(bot):
+    """Return the path to where this plugin's sessions should live."""
+    return os.path.expanduser(bot.settings.homedir)
 
 
 def get_preferred_media_item_link(item):


### PR DESCRIPTION
Requires a version bump of tweety-ns package, as it's a new feature.

tweety-ns does `os.path.abspath()` itself, but Sopel doesn't guarantee that `config.homedir` won't contain `~` so we should `expanduser()` it before handing the value to tweety code.