### PR TITLE
Band-aid fix for int fields in user that can be `None`

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -321,6 +321,12 @@ def output_user(bot, trigger, sn):
             bio = bio.replace(link['url'], link['expanded_url'])
         bio = tools.web.decode(bio)
 
+    # fixup undocumentedly nullable int fields
+    # upstream issue suggesting improvement: https://github.com/mahrtayyab/tweety/issues/87
+    for field in ('friends_count', 'followers_count', 'statuses_count', 'favourites_count'):
+        if type(getattr(user, field, None) is None:
+            setattr(user, field, 0)
+
     message = ('[Twitter] {user.name} (@{user.screen_name}){verified}{protected}{location}{url}'
                ' | {user.friends_count:,} friends, {user.followers_count:,} followers'
                ' | {user.statuses_count:,} tweets, {user.favourites_count:,} ♥s'


### PR DESCRIPTION
Tweety's documentation doesn't say anything about `Optional` or `| None` for these `User` fields, so the previous code could throw an error if any of the four expected-to-be-`int` profile values was 0—which is converted to `None` for some reason.\*

Note: Only ran into the case where favorites would be `None`, but `User` object code upstream sets all of these the same way so let's just make sure they're all safely handled.

(Fortunately it appears that Xitter doesn't allow empty `user.name`.)

_\* — Presumably the reverse-engineered JSON endpoint(s) Tweety uses just _don't send_ those `int` fields at all for values of `0`, so the `User` object defaults to `None` for them when it's setting itself up._