### PR TITLE
Handle x.com links by default

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -24,7 +24,7 @@ from sopel.config.types import (
 
 logger = tools.get_logger('twitter')
 
-DOMAIN_REGEX = r"https?://(?:m(?:obile)?\.)?twitter\.com/"
+DOMAIN_REGEX = r"https?://(?:m(?:obile)?\.)?(?:twitter|x)\.com/"
 STATUS_REGEX = r"(?:\w+|i/web)/status/(?P<status>\d+)"
 USER_REGEX = r"(?P<user>\w+)/?(?:\?.*)?$"
 NEWLINE_RUN_REGEX = re.compile(r"\s*\n[\n\s]*")


### PR DESCRIPTION
Xitter has begun yielding x.com links when the Share button is used.

Rejected idea that came up when writing this patch: Handling `www.` prefix on all domains, in addition to `m.` and `mobile.` (which also do work with `x.com`; I tested them).