### PR TITLE
Escape extra domains when lazily building URL patterns

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -184,7 +184,7 @@ def _twitter_alt_domains(path_regex):
         :rtype: List[re.Pattern]
         """
         return [
-            re.compile(r"https?://{}/{}".format(domain, path_regex))
+            re.compile(r"https?://{}/{}".format(re.escape(domain), path_regex))
             for domain in settings.twitter.alternate_domains
         ]
 


### PR DESCRIPTION
The configuration setting does not expect regular expressions. It's best practice to escape the `.` in a domain as `\.` when using it in a regex. Use of `re.escape()` was just forgotten when the `alternate_domains` setting got implemented.