### PR TITLE
Handle nullable `int` fields in `User`, for real this time

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -324,7 +324,7 @@ def output_user(bot, trigger, sn):
     # fixup undocumentedly nullable int fields
     # upstream issue suggesting improvement: https://github.com/mahrtayyab/tweety/issues/87
     for field in ('friends_count', 'followers_count', 'statuses_count', 'favourites_count'):
-        if type(getattr(user, field, None)) is None:
+        if getattr(user, field, None) is None:
             setattr(user, field, 0)
 
     message = ('[Twitter] {user.name} (@{user.screen_name}){verified}{protected}{location}{url}'


### PR DESCRIPTION
Previous fix (#54) didn't work; `type(None) is not None`.

Checking `type()` was wholly unnecessary.