### PR TITLE
Bump to newer Tweety library, 1.0.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ zip_safe = false
 include_package_data = true
 install_requires =
     sopel>=7.1,<9
-    tweety-ns>=0.9.9.5,<0.10
+    tweety-ns>=1.0,<1.1
 
 [options.entry_points]
 sopel.plugins =


### PR DESCRIPTION
Quick tests show that it still just works, and the changelog upstream only mentions added methods. Not that that means there aren't removals or changes (upstream docs are... not great), but I would prefer to just allow the newer library and deal with breakage if/when it surfaces.