### PR TITLE
Add fixvx.com to default alternate domains

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -36,7 +36,7 @@ class TwitterSection(StaticSection):
     show_quoted_tweets = BooleanAttribute('show_quoted_tweets', default=True)
     alternate_domains = ListAttribute(
         "alternate_domains",
-        default=["vxtwitter.com", "nitter.net"],
+        default=["vxtwitter.com", "fixvx.com", "nitter.net"],
     )
 
 


### PR DESCRIPTION
Shorter companion to vxtwitter.com, run by the same person on the same forked software stack.