### PR TITLE
Perform graceful truncation of overly long tweet text

### DIFF
--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -250,12 +250,18 @@ def output_status(bot, trigger, id_):
         bot.say("Can't access Twitter data. Please try again later.")
         return
 
-    template = "[Twitter] {tweet} | {RTs} RTs | {hearts} ♥s | Posted: {posted}"
+    preface = "[Twitter] {tweet}"
+    postface = " | {RTs} RTs | {hearts} ♥s | Posted: {posted}"
 
-    bot.say(template.format(tweet=format_tweet(tweet),
-                            RTs=tweet.retweet_counts,
-                            hearts=tweet.likes,
-                            posted=format_time(bot, trigger, tweet.created_on)))
+    bot.say(
+        preface.format(tweet=format_tweet(tweet)),
+        truncation=' […]',
+        trailing=postface.format(
+            RTs=tweet.retweet_counts,
+            hearts=tweet.likes,
+            posted=format_time(bot, trigger, tweet.created_on),
+        ),
+    )
 
     if (
         bot.config.twitter.show_quoted_tweets
@@ -263,10 +269,15 @@ def output_status(bot, trigger, id_):
         and tweet.quoted_tweet is not None
     ):
         tweet = tweet.quoted_tweet
-        bot.say(template.format(tweet='Quoting: ' + format_tweet(tweet),
-                                RTs=tweet.retweet_counts,
-                                hearts=tweet.likes,
-                                posted=format_time(bot, trigger, tweet.created_on)))
+        bot.say(
+            preface.format(tweet=format_tweet(tweet)),
+            truncation=' […]',
+            trailing=postface.format(
+                RTs=tweet.retweet_counts,
+                hearts=tweet.likes,
+                posted=format_time(bot, trigger, tweet.created_on),
+            ),
+        )
 
 
 def output_user(bot, trigger, sn):


### PR DESCRIPTION
This didn't actually take as long as I thought it might. Starting to think those `truncation` and `trailing` args to `bot.say()` really were brilliant (but I can't say that because they were my idea 😁).

Compare 1.3.6 (Yuzu) to this patch (SopelTest):

> 13:33:41 <~dgw> https://twitter.com/Spicy_Wolf_Prj/status/1767128338525753842
>
> 13:33:42 <&Yuzu> [Twitter] 『狼と香辛料』🍎4月1日(月)25:30よりテレ東ほかにて放送！ (@Spicy_Wolf_Prj): .｡.:✽・ﾟ ⏎ 初回放送4月1日(月)25:30より ⏎ テレ東ほかにて放送決定 ⏎ .｡.:✽・ﾟ ⏎ 放送情報詳細はこちら🔽 ⏎ https://spice-and-wolf.com/onair/ ⏎ 更に、今週3月17日(日)は先行上映会‼️ ⏎ ご好評につき、3月13日(水)0時より、 ⏎ 新宿・梅田のチケットが発売開始🎫
>
> 13:33:43 \<SopelTest> [Twitter] 『狼と香辛料』🍎4月1日(月)25:30よりテレ東ほかにて放送！ (@Spicy_Wolf_Prj): .｡.:✽・ﾟ ⏎ 初回放送4月1日(月)25:30より ⏎ テレ東ほかにて放送決定 ⏎ .｡.:✽・ﾟ ⏎ 放送情報詳細はこちら🔽 ⏎ https://spice-and-wolf.com/onair/ ⏎ 更に、今週3月17日(日)は先行上映会‼️ ⏎ […] | 2756 RTs | 7351 ♥s | Posted: 2024-03-11 - 10:00:02 UTC