### PR TITLE
Bump Tweety to 1.1.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,7 @@ keywords = [
 requires-python = ">=3.8, <4"
 dependencies = [
     "sopel>=7.1,<9",
-    "tweety-ns>=1.0,<1.1",
+    "tweety-ns~=1.1.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
For the next non-patch release of this plugin, the upper version bound should probably be removed. Users can most likely downgrade `tweety-ns` themselves if a newer version causes problems, but they'll have trouble installing a newer version if an older one stops working.

The same non-patch release should drop Sopel<8, which somewhat dictates its timing (NET Sopel 8.0 stable release).