### PR TITLE
Use new `is_user_authorized` attribute to check session state

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ keywords = [
 # requires-python = ">=3.8, <4"
 dependencies = [
     "sopel>=7.1,<9",
-    "tweety-ns~=1.1.2",
+    "tweety-ns~=1.1.4",
 ]
 
 [project.urls]

--- a/sopel_twitter/__init__.py
+++ b/sopel_twitter/__init__.py
@@ -219,7 +219,7 @@ def output_status(bot, trigger, id_):
         # try to use saved session
         app.connect()
 
-        if not app.session.logged_in:
+        if not app.is_user_authorized:
             # existing session not present
             app.sign_in(bot.settings.twitter.username, bot.settings.twitter.password)
 
@@ -286,7 +286,7 @@ def output_user(bot, trigger, sn):
         # try to use saved session
         app.connect()
 
-        if not app.session.logged_in:
+        if not app.is_user_authorized:
             # existing session not present
             app.sign_in(bot.settings.twitter.username, bot.settings.twitter.password)
 


### PR DESCRIPTION
Minimum `tweety-ns` version is now 1.1.4, the version in which this new attribute was added.

This might reduce #62, but the real fix will be updated exception handling.