### PR TITLE
Update tweety-ns to ~=2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ readme = { file=["README.md", "NEWS"], content-type="text/markdown" }
 
 [project]
 name = "sopel-twitter"
-version = "1.3.9"
+version = "1.4.0"
 description = "A Twitter plugin for Sopel"
 
 authors = [
@@ -38,11 +38,10 @@ keywords = [
   "irc",
 ]
 
-# Python spec should be enabled along with bumping `sopel` to 8+
-# requires-python = ">=3.8, <4"
+requires-python = ">=3.9, <4"
 dependencies = [
-    "sopel>=7.1,<9",
-    "tweety-ns~=1.1.4",
+    "sopel>=8,<9",
+    "tweety-ns~=2.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
Fixes #69
Fixes "Can't access Twitter data. Please try again later."

Better to have it work except for edge cases than not work at all.
tweety-ns seems to require python 3.8+, so may as well do that here too.

CC @dgw